### PR TITLE
Added access-options view

### DIFF
--- a/mobileapp/www/css/index.css
+++ b/mobileapp/www/css/index.css
@@ -685,3 +685,13 @@ body {
     margin-bottom: 1em;
 }
 
+#access-options {
+    margin 0 auto;
+    padding-top: 25%;
+    text-align: center;
+}
+
+#access-options > button {
+    display: block;
+    margin: 10px auto;
+}

--- a/mobileapp/www/index.html
+++ b/mobileapp/www/index.html
@@ -165,8 +165,14 @@
 	  </div>
 	</form>
       </div>
+
+      <div id="access-options" class="view">
+        <button id="has-account-btn" class="btn btn-primary">I Have an Account</button>
+        <br>
+        <button id="register-btn2" class="btn btn-primary">Create an Account</button>
+    </div>
       
-      <div id="account-login" class="view active">
+      <div id="account-login" class="view">
 	<form id="login-form" class="input-group input-group-lg">
 	  <input placeholder="Username"
 		 autocapitalize="off"

--- a/mobileapp/www/js/index.js
+++ b/mobileapp/www/js/index.js
@@ -53,9 +53,7 @@ var app = {
     
     this.card =  new crypton.Card();
     this.bindEvents();
-    $('#password-login').show();
-    $('#username-login').show();
-    
+
     function defaultLoginBehavior () {
       app.enableLoginButtons();
       app.switchView('#account-login');
@@ -101,7 +99,7 @@ var app = {
       });
     } else {
       // check if keychain is supported
-      defaultLoginBehavior();
+      app.switchView('#access-options');
     }
    // Offline
     window.Offline.options = {
@@ -181,9 +179,14 @@ var app = {
       app.about();
     });
     
-    $("#register-btn").click(function (e) {
+    $("#register-btn, #register-btn2").click(function (e) {
       e.preventDefault();
       app.beginRegistration();
+    });
+
+    $("#has-account-btn").click(function(e) {
+      e.preventDefault();
+      app.switchView('#account-login');
     });
 
     $("#register-generate-cancel-btn").click(function (e) {


### PR DESCRIPTION
This addresses issue #104 

So looking at how things are linked together, I basically just added a view that prompts the user for creds (as I had to account for users who chose to forget their credentials) or to create an account. This is solely based off whether `localStorage` has a username. This should play just fine with touchID as that functionality bypasses any view calls and goes straight to `app.login()`.