### PR TITLE
Create Account: Remove username if it matches localStorage.lastUserLogin

### DIFF
--- a/mobileapp/www/js/index.js
+++ b/mobileapp/www/js/index.js
@@ -802,6 +802,9 @@ var app = {
     // generate a long password
     var passphrase = generatePassphrase();
     // display new form
+    if (window.localStorage.lastUserLogin == $('#username-generate').val()) {
+      $('#username-generate').val('');
+    }
     $('#password-generate').val(passphrase);
     $('#username-generate').focus();
   },


### PR DESCRIPTION
This address issue #103 and supplements parts of PR #109 

This clears the username field in the Create Account view if the username is in `localStorage.lastUserLogin`