### PR TITLE
Reapplied touchID

### DIFF
--- a/mobileapp/www/css/index.css
+++ b/mobileapp/www/css/index.css
@@ -423,7 +423,7 @@ input[type="password"]:focus {
     font-family: WorkSans;
     padding: 1rem;
     font-weight: normal;
-    margin: 1rem 0;
+    margin: 0.5rem 0;
     -webkit-border-radius: 5px;
 }
 
@@ -1049,3 +1049,6 @@ body {
     margin-bottom: 1em;
 }
 
+#my-options-pane.view.active {
+    overflow: scroll;
+}

--- a/mobileapp/www/index.html
+++ b/mobileapp/www/index.html
@@ -311,6 +311,13 @@ height: 2.5rem;"></a>
 		    id="forget-credentials"
 		    class="btn btn-success">Forget credentials</button>
 	  </p>
+      <div id="touchid-wrapper">
+        <p class="option">
+        <button type="button"
+          id="use-touchid"
+          class="btn btn-success">Toggle Touch ID</button>
+        </p>
+      </div>
 	  <p class="option">
 	    <button type="button"
 		    id="display-passphrase"


### PR DESCRIPTION
One little bug...
Steps to reproduce:
- Create or login to account manually (e.g. forget credentials or delete and reinstall app)
- Login then go to Options
  - TouchID option will NOT visible
- Close app then log back in with credentials saved
  - TouchID option visible

I suspect since it's not finding anything in the keychain it's hiding it.